### PR TITLE
2 add drive command to drivetrain

### DIFF
--- a/commands/drive.py
+++ b/commands/drive.py
@@ -17,7 +17,6 @@ class Drive(SafeCommand):
         getPeriod: Callable[[], int],
         drivetrain: Drivetrain,
         xbox_remote: commands2.button.CommandXboxController,
-        is_field_relative: Callable[[], bool]
     ):
         super().__init__()
         self.addRequirements(drivetrain)
@@ -28,7 +27,6 @@ class Drive(SafeCommand):
         self.m_xspeedLimiter = SlewRateLimiter(3)
         self.m_yspeedLimiter = SlewRateLimiter(3)
         self.m_rotLimiter = SlewRateLimiter(3)
-        self.is_field_relative = is_field_relative
 
     def execute(self):
         x_speed = (
@@ -45,7 +43,10 @@ class Drive(SafeCommand):
             self.m_rotLimiter.calculate(self.xbox_remote.getRightX())
             * subsystems.drivetrain.k_max_angular_speed
         )
-        self.drivetrain.drive(x_speed, y_speed, rot, self.is_field_relative(), self.get_period())
+        self.drivetrain.drive(x_speed, y_speed, rot, self.isFieldRelative(), self.get_period())
+
+    def isFieldRelative(self):
+        return self.xbox_remote.getRightBumper() <= 0
 
     def end(self, interrupted: bool) -> None:
-        self.drivetrain.drive(0.0, 0.0, 0.0, self.is_field_relative(), self.get_period())
+        self.drivetrain.drive(0.0, 0.0, 0.0, self.isFieldRelative(), self.get_period())

--- a/commands/drive.py
+++ b/commands/drive.py
@@ -17,6 +17,7 @@ class Drive(SafeCommand):
         getPeriod: Callable[[], int],
         drivetrain: Drivetrain,
         xbox_remote: commands2.button.CommandXboxController,
+        is_field_relative: Callable[[], bool]
     ):
         super().__init__()
         self.addRequirements(drivetrain)
@@ -27,6 +28,7 @@ class Drive(SafeCommand):
         self.m_xspeedLimiter = SlewRateLimiter(3)
         self.m_yspeedLimiter = SlewRateLimiter(3)
         self.m_rotLimiter = SlewRateLimiter(3)
+        self.is_field_relative = is_field_relative
 
     def execute(self):
         x_speed = (
@@ -41,11 +43,9 @@ class Drive(SafeCommand):
         )
         rot = (
             self.m_rotLimiter.calculate(self.xbox_remote.getRightX())
-            * -1
             * subsystems.drivetrain.k_max_angular_speed
         )
-
-        self.drivetrain.drive(x_speed, y_speed, rot, True, self.get_period())
+        self.drivetrain.drive(x_speed, y_speed, rot, self.is_field_relative(), self.get_period())
 
     def end(self, interrupted: bool) -> None:
-        self.drivetrain.drive(0.0, 0.0, 0.0, True, self.get_period())
+        self.drivetrain.drive(0.0, 0.0, 0.0, self.is_field_relative(), self.get_period())

--- a/robot.py
+++ b/robot.py
@@ -10,6 +10,7 @@ from subsystems.drivetrain import Drivetrain
 
 
 class Robot(commands2.TimedCommandRobot):
+    xboxremote: commands2.button.CommandXboxController = None
     def robotInit(self):
         wpilib.LiveWindow.enableAllTelemetry()
         wpilib.LiveWindow.setEnabled(True)
@@ -20,7 +21,7 @@ class Robot(commands2.TimedCommandRobot):
         self.drivetrain = Drivetrain()
 
         self.drivetrain.setDefaultCommand(
-            Drive(lambda: self.getPeriod(), self.drivetrain, self.xboxremote)
+            Drive(lambda: self.getPeriod(), self.drivetrain, self.xboxremote, lambda: self.xboxremote.getRightBumper() <= 0)
         )
 
 

--- a/robot.py
+++ b/robot.py
@@ -10,7 +10,6 @@ from subsystems.drivetrain import Drivetrain
 
 
 class Robot(commands2.TimedCommandRobot):
-    xboxremote: commands2.button.CommandXboxController = None
     def robotInit(self):
         wpilib.LiveWindow.enableAllTelemetry()
         wpilib.LiveWindow.setEnabled(True)

--- a/robot.py
+++ b/robot.py
@@ -21,7 +21,7 @@ class Robot(commands2.TimedCommandRobot):
         self.drivetrain = Drivetrain()
 
         self.drivetrain.setDefaultCommand(
-            Drive(lambda: self.getPeriod(), self.drivetrain, self.xboxremote, lambda: self.xboxremote.getRightBumper() <= 0)
+            Drive(lambda: self.getPeriod(), self.drivetrain, self.xboxremote)
         )
 
 


### PR DESCRIPTION
Description
-----------
Ajout de la commande drive pour contrôler drivetrain. Le right bumper de la manette contrôle le switch a field relative. (Pressé = tank drive)
Closes #2 . 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Functions use camelCase
    - [x] Variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
- Command and subsytem safety :
    - [x] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [x] No commands or subsytems have a `setName()` method, unless necessary
    - [x] Commands have a `addRequirements()` method that includes all the subsystems they use
- [x] J'ai exécuté tout mon code en simulation.
